### PR TITLE
Remove manual support for prompt

### DIFF
--- a/ox-linuxmag-fr.el
+++ b/ox-linuxmag-fr.el
@@ -432,29 +432,11 @@ SRC-BLOCK is the Org parsed element containing this
 line.  BLOCK-TYPE is either \"console\" or \"code\".  INFO is a
 plist holding contextual information."
   (ox-linuxmag-fr--format-textp
-   (let* ((ox-linuxmag-fr--inline-code-style "code_5f_em")
-          (text (org-export-data
-                 (org-element-parse-secondary-string line '(code) src-block)
-                 info)))
-     (concat (ox-linuxmag-fr--src-block-prompt src-block) text))
+   (let* ((ox-linuxmag-fr--inline-code-style "code_5f_em"))
+     (org-export-data
+      (org-element-parse-secondary-string line '(code) src-block)
+      info))
    block-type))
-
-(defun ox-linuxmag-fr--src-block-prompt (src-block)
-  "Return a string corresponding to the prompt for SRC-BLOCK.
-
-The prompt of an SRC-BLOCK is defined with
-
-  #+ATTR_LINUXMAG-FR: :type console :prompt '$ '"
-  (let* ((quoting-char ?')
-         (prompt-attribute (or
-                            (org-export-read-attribute :attr_linuxmag-fr src-block :prompt)
-                            "")))
-    ;; remove quotes if any:
-    (if (and (length> prompt-attribute 2)
-             (eq (aref prompt-attribute 0) quoting-char)
-             (eq (aref prompt-attribute (1- (length prompt-attribute))) quoting-char))
-        (substring-no-properties prompt-attribute 1 -1)
-      prompt-attribute)))
 
 (defun ox-linuxmag-fr--table (table contents info)
   "Transcode a TABLE element from Org to ODT.

--- a/test/ox-linuxmag-fr-tests.el
+++ b/test/ox-linuxmag-fr-tests.el
@@ -236,22 +236,6 @@ bar
 #+end_src")
   (should (ox-linuxmag-fr-tests-contain "<text:p text:style-name=\"console\">bar</text:p>")))
 
-(ert-deftest ox-linuxmag-fr-tests-src-block-with-prompt ()
-  (ox-linuxmag-fr-tests-export "
-#+ATTR_LINUXMAG-FR: :prompt $
-#+begin_src text
-bar
-#+end_src")
-  (should (ox-linuxmag-fr-tests-contain "<text:p text:style-name=\"code\">$bar</text:p>")))
-
-(ert-deftest ox-linuxmag-fr-tests-src-block-with-quoted-prompt ()
-  (ox-linuxmag-fr-tests-export "
-#+ATTR_LINUXMAG-FR: :prompt '$ '
-#+begin_src text
-bar
-#+end_src")
-  (should (ox-linuxmag-fr-tests-contain "<text:p text:style-name=\"code\">$ bar</text:p>")))
-
 (ert-deftest ox-linuxmag-fr-tests-src-block-default-with-indentation ()
   (ox-linuxmag-fr-tests-export "
 #+begin_src text


### PR DESCRIPTION
The same can be done (for all backends) with something like (https://emacs.stackexchange.com/questions/44958/can-i-insert-a-prefix-to-org-babel-source-code-lines-on-export/44970#44970):

```
(defun org-export-insert-shell-prompt (_backend)
  (org-babel-map-src-blocks nil         ; nil implies current buffer
    (let (;; capture macro-defined variables
          (lang lang)
          (beg-body beg-body)
          (end-body end-body)
          ;; other variables
          (shell-langs '("sh" "shell"))
          (prefix "$ ")
          (is-contd-from-prev-line nil)) ; t if prev line ends in '\'; nil otherwise
      (when (member lang shell-langs)
        (goto-char beg-body)
        (skip-chars-forward "\n\s" end-body) ; not sure why OP included '-'
        (while (< (point) end-body)
          (if (not is-contd-from-prev-line) ; skip prefix if continuing previous line
                (insert prefix))
          (end-of-line)
          (if (eq ?\\ (char-after (- (point) 1))) ; check if statement continues in next line
              (setq is-contd-from-prev-line t)
            (setq is-contd-from-prev-line nil))
          (skip-chars-forward "\n\s" end-body))))))

(add-hook 'org-export-before-parsing-hook #'my-insert-shell-prompt)
```